### PR TITLE
Fix UPDI EEPROM access for GDB 0x81 memory requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **Fixed:**
      - In `set_one_register_handler` in `handler.py`, there were two errors when setting a single register. First, there was no conversion to strings, and second, the register numbers can be a single hex digits.
      - Now, `sram_masked_read` and `sram_masked_write` will read from registers/write to registers when the address is < `iooffset`. This means that for targets with general registers in the SRAM area below `iooffset` (i.e., 0x20), there is a consistent source and destination for memory transfers created by the debugger.
+     - EEPROM access through the GDB `0x81xxxx` memory segment now works for UPDI devices with nonzero EEPROM base addresses. The `Memory` layer keeps EEPROM offsets relative, and the transport-specific backend adds the physical base once.
 
 - **Added:**
      - UPDI functionality

--- a/docs/UPDI-notes.md
+++ b/docs/UPDI-notes.md
@@ -2,7 +2,25 @@
 
 ## EEPROM
 
-EEPROM access does not work - check!
+EEPROM access over the GDB memory interface is fixed.
+
+The problem was an address translation mismatch between the GDB-facing
+`Memory` layer and the UPDI NVM backend:
+
+- GDB accesses EEPROM through the `0x81xxxx` memory segment and already
+  passes an EEPROM-relative offset such as `0x0002`.
+- The UPDI NVM provider expects exactly that relative offset and adds the
+  physical EEPROM base address from the device description, for example
+  `0x1400` on parts such as the ATtiny3217.
+- The old implementation in `Memory.eeprom_read()` and
+  `Memory.eeprom_write()` subtracted the EEPROM base once before calling the
+  backend. For UPDI devices with a nonzero EEPROM base, this produced the
+  wrong raw address.
+
+The fix is to keep the EEPROM offset relative in the `Memory` layer and let
+the transport-specific NVM implementation add the physical base exactly once.
+Regression tests now cover this path with a real UPDI device definition
+(`attiny3217`) so that nonzero EEPROM bases are exercised.
 
 ## Memory access API
 

--- a/docs/UPDI-notes.md
+++ b/docs/UPDI-notes.md
@@ -11,7 +11,7 @@ The problem was an address translation mismatch between the GDB-facing
   passes an EEPROM-relative offset such as `0x0002`.
 - The UPDI NVM provider expects exactly that relative offset and adds the
   physical EEPROM base address from the device description, for example
-  `0x1400` on parts such as the ATtiny3217.
+  `0x1400` on parts such as the ATmega4809.
 - The old implementation in `Memory.eeprom_read()` and
   `Memory.eeprom_write()` subtracted the EEPROM base once before calling the
   backend. For UPDI devices with a nonzero EEPROM base, this produced the
@@ -20,7 +20,7 @@ The problem was an address translation mismatch between the GDB-facing
 The fix is to keep the EEPROM offset relative in the `Memory` layer and let
 the transport-specific NVM implementation add the physical base exactly once.
 Regression tests now cover this path with a real UPDI device definition
-(`attiny3217`) so that nonzero EEPROM bases are exercised.
+(`atmega4809`) so that nonzero EEPROM bases are exercised.
 
 ## Memory access API
 

--- a/pyavrocd/memory.py
+++ b/pyavrocd/memory.py
@@ -468,16 +468,15 @@ class Memory():
         Read EEPROM content from the AVR
         Needs to be handled here because depending on programm_mode, different memtypes have to be used
 
-        :param address: absolute address to start reading from
+        :param address: EEPROM-relative offset to start reading from
         :param numbytes: number of bytes to read
         """
         self.logger.debug("Reading %d bytes from EEPROM at %X", numbytes, address)
-        # The debugger protocols (via pymcuprog) use memory-types with zero-offsets
-        # So the offset is subtracted here (and added later in the debugger)
+        # GDB's 0x81 memory segment already provides an EEPROM-relative offset.
+        # The transport-specific NVM providers add the physical EEPROM base.
         if self.dbg.memory_info is None:
             raise FatalError("No memory info available")
-        offset : int = (self.dbg.memory_info.memory_info_by_name('eeprom'))['address']
-        return self.dbg.device.read(self.dbg.memory_info.memory_info_by_name('eeprom'), address-offset,
+        return self.dbg.device.read(self.dbg.memory_info.memory_info_by_name('eeprom'), address,
                                         numbytes, self.programming_mode)
 
     def eeprom_write(self, address : int , data : bytes) -> None:
@@ -485,14 +484,13 @@ class Memory():
         Write EEPROM content to the AVR
         Needs to be handled here because depending on programm_mode, different memtypes have to be used
 
-        :param address: absolute address in EEPROM to start writing
+        :param address: EEPROM-relative offset to start writing at
         :param data: content to store to EEPROM
         """
         self.logger.debug("Writing %d bytes to EEPROM at %X", len(data), address)
-        # The debugger protocols (via pymcuprog) use memory-types with zero-offsets
-        # So the offset is subtracted here (and added later in the debugger)
+        # GDB's 0x81 memory segment already provides an EEPROM-relative offset.
+        # The transport-specific NVM providers add the physical EEPROM base.
         if self.dbg.memory_info is None:
             raise FatalError("No memory info available")
-        offset : int = (self.dbg.memory_info.memory_info_by_name('eeprom'))['address']
-        return self.dbg.device.write(self.dbg.memory_info.memory_info_by_name('eeprom'), address-offset,
+        return self.dbg.device.write(self.dbg.memory_info.memory_info_by_name('eeprom'), address,
                                          data, self.programming_mode)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -4,6 +4,8 @@ The test suit for the Memory class
 #pylint: disable=protected-access,missing-function-docstring,consider-using-f-string,invalid-name,line-too-long,missing-class-docstring,too-many-public-methods
 from unittest.mock import Mock, MagicMock, call, create_autospec, patch
 from unittest import TestCase
+from pymcuprog.deviceinfo import deviceinfo
+from pyavrocd.deviceinfo.devices.attiny3217 import DEVICE_INFO as ATTINY3217_DEVICE_INFO
 from pyavrocd.xavrdebugger import XAvrDebugger
 from pyavrocd.errors import FatalError
 from pyavrocd.memory import Memory
@@ -13,6 +15,20 @@ class TestMemory(TestCase):
 
     def setUp(self):
         self.mem = None
+
+    def set_up_real_updi(self):
+        mock_dbg = create_autospec(XAvrDebugger, spec_set=False, instance=True)
+        mock_mon = create_autospec(MonitorCommand, spec_set=True, instance=True)
+        mock_mon.is_noinitialload.return_value = False
+        mock_dbg.memory_info = deviceinfo.DeviceMemoryInfo(ATTINY3217_DEVICE_INFO)
+        mock_dbg.device_info = ATTINY3217_DEVICE_INFO
+        mock_dbg.transport = MagicMock()
+        mock_dbg.device = Mock()
+        mock_dbg.device.avr = Mock()
+        mock_dbg.get_iooffset.return_value = 0x20
+        mock_dbg.get_iface.return_value = "updi"
+        mock_dbg.flashmemtype = 123
+        self.mem = Memory(mock_dbg, mock_mon)
 
     def set_up(self):
         mock_dbg = create_autospec(XAvrDebugger, spec_set=False, instance=True)
@@ -397,3 +413,42 @@ class TestMemory(TestCase):
         self.set_up()
         self.mem.dbg.write_usig.side_effect = FatalError("fail")
         self.assertEqual(self.mem.usig_write(0x00, bytearray([0x12, 0x34])), 'E13')
+    def test_eeprom_read_uses_programming_mode_flag(self):
+        self.set_up()
+        self.mem.programming_mode = True
+        self.mem.dbg.device.read.return_value = bytearray([0x12, 0x34])
+        self.assertEqual(self.mem.eeprom_read(2, 2), bytearray([0x12, 0x34]))
+        args = self.mem.dbg.device.read.call_args.args
+        self.assertEqual(args[0], self.mem.dbg.memory_info.memory_info_by_name('eeprom'))
+        self.assertEqual(args[2], 2)
+        self.assertTrue(args[3])
+
+    def test_eeprom_write_uses_programming_mode_flag(self):
+        self.set_up()
+        self.mem.programming_mode = True
+        self.mem.dbg.device.write.return_value = None
+        self.mem.eeprom_write(3, bytearray([0xAA]))
+        args = self.mem.dbg.device.write.call_args.args
+        self.assertEqual(args[0], self.mem.dbg.memory_info.memory_info_by_name('eeprom'))
+        self.assertEqual(args[2], bytearray([0xAA]))
+        self.assertTrue(args[3])
+
+    def test_readmem_eeprom_updi_keeps_relative_offset(self):
+        self.set_up_real_updi()
+        self.mem.dbg.device.read.return_value = bytearray([1, 2, 3])
+        self.assertEqual(self.mem.readmem("810002", "3"), bytearray([1, 2, 3]))
+        args = self.mem.dbg.device.read.call_args.args
+        self.assertEqual(args[0], self.mem.dbg.memory_info.memory_info_by_name('eeprom'))
+        self.assertEqual(args[1], 2)
+        self.assertEqual(args[2], 3)
+        self.assertFalse(args[3])
+
+    def test_writemem_eeprom_updi_keeps_relative_offset(self):
+        self.set_up_real_updi()
+        self.mem.dbg.device.write.return_value = None
+        self.assertEqual(self.mem.writemem("810002", bytearray([1, 2, 3])), "OK")
+        args = self.mem.dbg.device.write.call_args.args
+        self.assertEqual(args[0], self.mem.dbg.memory_info.memory_info_by_name('eeprom'))
+        self.assertEqual(args[1], 2)
+        self.assertEqual(args[2], bytearray([1, 2, 3]))
+        self.assertFalse(args[3])

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -5,7 +5,7 @@ The test suit for the Memory class
 from unittest.mock import Mock, MagicMock, call, create_autospec, patch
 from unittest import TestCase
 from pymcuprog.deviceinfo import deviceinfo
-from pyavrocd.deviceinfo.devices.attiny3217 import DEVICE_INFO as ATTINY3217_DEVICE_INFO
+from pyavrocd.deviceinfo.devices.atmega4809 import DEVICE_INFO as ATMEGA4809_DEVICE_INFO
 from pyavrocd.xavrdebugger import XAvrDebugger
 from pyavrocd.errors import FatalError
 from pyavrocd.memory import Memory
@@ -20,8 +20,8 @@ class TestMemory(TestCase):
         mock_dbg = create_autospec(XAvrDebugger, spec_set=False, instance=True)
         mock_mon = create_autospec(MonitorCommand, spec_set=True, instance=True)
         mock_mon.is_noinitialload.return_value = False
-        mock_dbg.memory_info = deviceinfo.DeviceMemoryInfo(ATTINY3217_DEVICE_INFO)
-        mock_dbg.device_info = ATTINY3217_DEVICE_INFO
+        mock_dbg.memory_info = deviceinfo.DeviceMemoryInfo(ATMEGA4809_DEVICE_INFO)
+        mock_dbg.device_info = ATMEGA4809_DEVICE_INFO
         mock_dbg.transport = MagicMock()
         mock_dbg.device = Mock()
         mock_dbg.device.avr = Mock()


### PR DESCRIPTION
## Summary
- fix EEPROM access through the GDB `0x81xxxx` memory segment for UPDI targets with nonzero EEPROM base addresses
- document the address translation issue and the fix in `docs/UPDI-notes.md`
- add regression coverage in `tests/test_memory.py` using a real UPDI device definition with a nonzero EEPROM base (`atmega4809`)

## Problem
`Memory.eeprom_read()` and `Memory.eeprom_write()` were subtracting the EEPROM base before calling the transport-specific backend.

For UPDI targets, the GDB-facing memory layer already receives an EEPROM-relative offset from the `0x81xxxx` segment, and the UPDI NVM provider adds the physical EEPROM base itself. That meant the EEPROM base was effectively applied twice, producing wrong raw addresses for devices whose EEPROM is not based at zero.

## Fix
Keep the address relative in the `Memory` layer and let the transport-specific backend add the physical EEPROM base exactly once.

## Verification
- `poetry run pytest -q tests/test_memory.py tests/test_xnvmupdi.py`
- `poetry run mypy pyavrocd/memory.py tests/test_memory.py tests/test_xnvmupdi.py`